### PR TITLE
remove include line for cdc.config post migration

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -186,9 +186,6 @@ manifest {
 // Load modules.config for DSL2 module specific options
 includeConfig 'conf/modules.config'
 
-// Load CDC config for operating on internal compute infrastructure
-includeConfig 'conf/cdc.config'
-
 // Function to ensure that resource requirements don't go beyond
 // a maximum limit
 def check_max(obj, type) {


### PR DESCRIPTION
Test using: 

First locally copy `mpxvgfa.sif` to `polkapox/assets`  

`nextflow run main.nf --indir /scicomp/groups-pure/Projects/scbs_mpob/JRowell_ick4/mpox_testing/paired/ --outdir /scicomp/groups-pure/Projects/scbs_mpob/JRowell_ick4/mpox_testing/results/ --project_name test -config /scicomp/reference/nextflow/configs/cdc-dev.config -profile singularity,rosalind`
